### PR TITLE
MAINT refactor to do without FeatureInput

### DIFF
--- a/educe/rst_dt/learning/cmd/extract.py
+++ b/educe/rst_dt/learning/cmd/extract.py
@@ -16,9 +16,11 @@ import educe.corpus
 import educe.glozz
 import educe.stac
 import educe.util
+
+from educe.rst_dt import ptb as r_ptb
 from educe.learning.orange_format import dump_orange_tab_file
 from ..args import add_usual_input_args
-from ..base import read_corpus_inputs, extract_pair_features
+from ..base import extract_pair_features
 
 
 NAME = 'extract'
@@ -64,12 +66,18 @@ def config_argparser(parser):
 def main(args):
     "main for feature extraction mode"
     # retrieve parameters
-    inputs = read_corpus_inputs(args)
     feature_set = args.feature_set
     live = args.parsing
 
+    # load corpora
+    is_interesting = educe.util.mk_is_interesting(args)
+    reader = educe.rst_dt.Reader(args.corpus)
+    anno_files = reader.filter(reader.files(), is_interesting)
+    corpus = reader.slurp(anno_files, verbose=True)
+    ptb = r_ptb.reader(args.ptb)
+
     # extract instances
-    X = extract_pair_features(inputs, feature_set=feature_set, live=live)
+    X = extract_pair_features(feature_set, corpus, ptb, live=live)
 
     # dump instances to file
     if not os.path.exists(args.output):

--- a/educe/rst_dt/learning/cmd/features.py
+++ b/educe/rst_dt/learning/cmd/features.py
@@ -10,7 +10,6 @@ Emit a list of known features
 
 from __future__ import print_function
 
-from ..base import read_help_inputs
 from ..args import add_usual_input_args
 
 NAME = 'features'
@@ -34,5 +33,4 @@ def config_argparser(parser):
 
 def main(args):
     "main for feature listing mode"
-    inputs = read_help_inputs(args)
-    print(args.feature_set.PairKeys(inputs).help_text())
+    print(args.feature_set.PairKeys().help_text())

--- a/educe/rst_dt/learning/features.py
+++ b/educe/rst_dt/learning/features.py
@@ -298,13 +298,12 @@ class SingleEduSubgroup_Ptb(SingleEduSubgroup):
         super(SingleEduSubgroup_Ptb, self).__init__(desc, self._features)
 
 
-
 # ---------------------------------------------------------------------
 # EDU pairs
 # ---------------------------------------------------------------------
 
 class PairSubGroup_Core(PairSubgroup):
-    "core features"
+    """core features"""
 
     def __init__(self):
         desc = self.__doc__.strip()
@@ -333,8 +332,7 @@ class PairSubgroup_Gap(PairSubgroup):
 class PairSubgroup_Tuple(PairSubgroup):
     "artificial tuple features"
 
-    def __init__(self, inputs, sf_cache):
-        self.corpus = inputs.corpus
+    def __init__(self, sf_cache):
         self.sf_cache = sf_cache
         desc = self.__doc__.strip()
         keys =\
@@ -367,31 +365,27 @@ class PairSubgroup_Basket(PairSubgroup):
 class SingleEduKeys(BaseSingleEduKeys):
     """Single EDU features"""
 
-    def __init__(self, inputs):
+    def __init__(self):
         groups = [
             SingleEduSubgroup_Meta(),
             SingleEduSubgroup_Text(),
             SingleEduSubgroup_Ptb()
         ]
-        #if inputs.debug:
-        #    groups.append(SingleEduSubgroup_Debug())
-        super(SingleEduKeys, self).__init__(inputs, groups)
+        super(SingleEduKeys, self).__init__(groups)
 
 
 class PairKeys(BasePairKeys):
     """Features on a pair of EDUs"""
 
-    def __init__(self, inputs, sf_cache=None):
+    def __init__(self, sf_cache=None):
         groups = [
             PairSubGroup_Core(),
             PairSubgroup_Gap(),
-            PairSubgroup_Tuple(inputs, sf_cache),
+            PairSubgroup_Tuple(sf_cache),
             PairSubgroup_Basket()
         ]
-        #if inputs.debug:
-        #    groups.append(PairSubgroup_Debug())
-        super(PairKeys, self).__init__(inputs, groups, sf_cache)
+        super(PairKeys, self).__init__(groups, sf_cache)
 
-    def init_single_features(self, inputs):
+    def init_single_features(self):
         """Init features defined on single EDUs"""
-        return SingleEduKeys(inputs)
+        return SingleEduKeys()

--- a/educe/rst_dt/learning/features_li2014.py
+++ b/educe/rst_dt/learning/features_li2014.py
@@ -632,8 +632,7 @@ class PairSubgroup_Word(PairSubgroup):
         MagicKey.discrete_fn(ptb_word_last2_pairs)
     ]
 
-    def __init__(self, inputs, sf_cache):
-        self.corpus = inputs.corpus
+    def __init__(self, sf_cache):
         self.sf_cache = sf_cache
         desc = self.__doc__.strip()
         super(PairSubgroup_Word, self).__init__(desc, self._features)
@@ -651,8 +650,7 @@ class PairSubgroup_Pos(PairSubgroup):
         MagicKey.discrete_fn(ptb_pos_tag_first_pairs)
     ]
 
-    def __init__(self, inputs, sf_cache):
-        self.corpus = inputs.corpus
+    def __init__(self, sf_cache):
         self.sf_cache = sf_cache
         desc = self.__doc__.strip()
         super(PairSubgroup_Pos, self).__init__(desc, self._features)
@@ -672,8 +670,7 @@ class PairSubgroup_Para(PairSubgroup):
         MagicKey.continuous_fn(num_paragraphs_between_div3)
     ]
 
-    def __init__(self, inputs, sf_cache):
-        self.corpus = inputs.corpus
+    def __init__(self, sf_cache):
         self.sf_cache = sf_cache
         desc = self.__doc__.strip()
         super(PairSubgroup_Para, self).__init__(desc, self._features)
@@ -704,8 +701,7 @@ class PairSubgroup_Sent(PairSubgroup):
         MagicKey.continuous_fn(rev_sentence_id_diff_div3),
     ]
 
-    def __init__(self, inputs, sf_cache):
-        self.corpus = inputs.corpus
+    def __init__(self, sf_cache):
         self.sf_cache = sf_cache
         desc = self.__doc__.strip()
         super(PairSubgroup_Sent, self).__init__(desc, self._features)
@@ -724,8 +720,7 @@ class PairSubgroup_Length(PairSubgroup):
         MagicKey.continuous_fn(num_tokens_diff_div5)
     ]
 
-    def __init__(self, inputs, sf_cache):
-        self.corpus = inputs.corpus
+    def __init__(self, sf_cache):
         self.sf_cache = sf_cache
         desc = self.__doc__.strip()
         super(PairSubgroup_Length, self).__init__(desc, self._features)
@@ -753,7 +748,7 @@ class PairSubgroup_Basket(PairSubgroup):
 class SingleEduKeys(BaseSingleEduKeys):
     """Single EDU features"""
 
-    def __init__(self, inputs):
+    def __init__(self):
         groups = [
             SingleEduSubgroup_Meta(),
             SingleEduSubgroup_Word(),
@@ -763,37 +758,33 @@ class SingleEduKeys(BaseSingleEduKeys):
             SingleEduSubgroup_Para(),
             SingleEduSubgroup_Sentence()
         ]
-        # if inputs.debug:
-        #     groups.append(SingleEduSubgroup_Debug())
-        super(SingleEduKeys, self).__init__(inputs, groups)
+        super(SingleEduKeys, self).__init__(groups)
 
 
 class PairKeys(BasePairKeys):
     """Features on a pair of EDUs"""
 
-    def __init__(self, inputs, sf_cache=None):
+    def __init__(self, sf_cache=None):
         groups = [
             # meta
             PairSubgroup_Core(),
             # feature type: 1
-            PairSubgroup_Word(inputs, sf_cache),
+            PairSubgroup_Word(sf_cache),
             # 2
-            PairSubgroup_Pos(inputs, sf_cache),
+            PairSubgroup_Pos(sf_cache),
             # 3
-            PairSubgroup_Para(inputs, sf_cache),
-            PairSubgroup_Sent(inputs, sf_cache),
+            PairSubgroup_Para(sf_cache),
+            PairSubgroup_Sent(sf_cache),
             # 4
-            PairSubgroup_Length(inputs, sf_cache),
+            PairSubgroup_Length(sf_cache),
             # 5
             # PairSubgroup_Syntax(),  # cf. basket
             # 6
             # PairSubgroup_Semantics(),
             PairSubgroup_Basket()  # basket feats for POS and syntax
         ]
-        # if inputs.debug:
-        #     groups.append(PairSubgroup_Debug())
-        super(PairKeys, self).__init__(inputs, groups, sf_cache)
+        super(PairKeys, self).__init__(groups, sf_cache)
 
-    def init_single_features(self, inputs):
+    def init_single_features(self):
         """Init features defined on single EDUs"""
-        return SingleEduKeys(inputs)
+        return SingleEduKeys()


### PR DESCRIPTION
`FeatureInput` is pervasively used in the feature extraction code of `educe.rst_dt.learning` with little if any benefit.
This PR flattens code, thus removing the need for `FeatureInput`, and effectively removes FeatureInput in `educe.rst_dt`.