### PR TITLE
Sklearn-ready branch for RST-DT

### DIFF
--- a/educe/rst_dt/corpus.py
+++ b/educe/rst_dt/corpus.py
@@ -111,37 +111,37 @@ class RstDtParser(object):
 
     def decode(self, doc_key):
         """Decode a document from the RST-DT (gold)"""
-        grouping = os.path.basename(id_to_path(doc_key))
-        doc = DocumentPlus(doc_key, grouping)
-
+        # create a DocumentPlus
         # the RST tree is currently pivotal to get all the layers of info
         orig_rsttree = self.corpus[doc_key]
         # convert relation labels if needed
         if self.rel_conv is not None:
             orig_rsttree = self.rel_conv(orig_rsttree)
-        doc.orig_rsttree = orig_rsttree
-        # TODO get EDUs here
-        # doc.edus.append(orig_rsttree.leaves())
-
-        # get text and doc structure
+        # the RST tree is backed by an RSTContext that contains the document
+        # text and structure (paragraphs and badly segmented sents)
         rst_context = treenode(orig_rsttree).context
-        doc.rst_context = rst_context
-        # directly store paragraphs and (badly segmented) sentences
-        paragraphs = rst_context.paragraphs
-        sentences_iter = (para.sentences for para in paragraphs)
-        sentences = list(itertools.chain.from_iterable(sentences_iter))
-        doc.paragraphs.extend(paragraphs)
-        doc.raw_sentences.extend(sentences)
+        # grouping is the document name
+        grouping = os.path.basename(id_to_path(doc_key))
+        # finally...
+        doc = DocumentPlus(doc_key, grouping, rst_context)
+
+        # TODO get EDUs here
+        # edus = orig_rsttree.leaves()
+        # doc.edus.extend(edus)
+        # attach original RST tree
+        doc.orig_rsttree = orig_rsttree
 
         # convert to binary tree
         rsttree = SimpleRSTTree.from_rst_tree(orig_rsttree)
         doc.rsttree = rsttree
+
         # convert to dep tree
         deptree = RstDepTree.from_simple_rst_tree(rsttree)
         doc.deptree = deptree
+
         # get EDUs (bad)
-        # TODO: get EDUs from orig_rsttree.leaves(),
-        # let document_plus do the left padding
+        # TODO: get EDUs from orig_rsttree.leaves() and let
+        # document_plus do the left padding
         doc.edus = doc.deptree.edus
 
         return doc

--- a/educe/rst_dt/learning/cmd/extract.py
+++ b/educe/rst_dt/learning/cmd/extract.py
@@ -106,6 +106,8 @@ def main(args):
         # to get proper sentence segmentation
         doc = doc.align_with_trees()
         doc = doc.align_with_tokens()
+        # dummy, fallback tokenization if there is no PTB gold or silver
+        doc = doc.align_with_raw_words()
 
         return doc
 

--- a/educe/rst_dt/learning/doc_vectorizer.py
+++ b/educe/rst_dt/learning/doc_vectorizer.py
@@ -169,7 +169,7 @@ class DocumentCountVectorizer(object):
         self.feature_set = feature_set
         # EXPERIMENTAL
         # preprocessor for each EDU
-        self.edu_preprocess = feature_set.edu_preprocess
+        self.doc_preprocess = feature_set.build_doc_preprocessor()
         # feature extractor for single EDUs
         sing_header, sing_extract = feature_set.build_edu_feature_extractor()
         self.sing_header = sing_header
@@ -199,7 +199,7 @@ class DocumentCountVectorizer(object):
     def _extract_feature_vectors(self, doc):
         """Extract feature vectors for all EDU pairs of a document"""
 
-        edu_preprocess = self.edu_preprocess
+        doc_preprocess = self.doc_preprocess
         sing_header = self.sing_header
         sing_extract = self.sing_extract
         pair_header = self.pair_header
@@ -207,7 +207,7 @@ class DocumentCountVectorizer(object):
         separator = self.separator
 
         # preprocess each EDU
-        edu_info = {edu: edu_preprocess(doc, edu) for edu in doc.edus}
+        edu_info = doc_preprocess(doc)
 
         # extract one feature vector per EDU pair
         feat_vecs = []

--- a/educe/rst_dt/learning/features.py
+++ b/educe/rst_dt/learning/features.py
@@ -2,390 +2,243 @@
 Feature extraction library functions for RST_DT corpus
 """
 
-from collections import Counter
-from functools import wraps
-import re
+from educe.learning.keys import Substance
+from .base import DocumentPlusPreprocessor
 
-from educe.learning.csv import tune_for_csv
-from educe.learning.keys import MagicKey
-from educe.learning.util import tuple_feature, underscore
-from .base import (SingleEduSubgroup, PairSubgroup,
-                   BaseSingleEduKeys, BasePairKeys,
-                   on_first_unigram, on_last_unigram,
-                   on_first_bigram, on_last_bigram,
-                   edu_feature, edu_pair_feature,
-                   feat_id, feat_start, feat_end,
-                   feat_grouping,
-                   get_sentence, get_paragraph)
+
+def build_doc_preprocessor():
+    """Build the preprocessor for feature extraction in each EDU of doc"""
+    return DocumentPlusPreprocessor().preprocess
 
 
 # ---------------------------------------------------------------------
 # single EDUs
 # ---------------------------------------------------------------------
 
-def clean_edu_text(text):
-    """
-    Strip metadata from EDU text and compress extraneous whitespace
-    """
-    clean_text = text
-    clean_text = re.sub(r'(\.|,)*$', r'', clean_text)
-    clean_text = re.sub(r'^"', r'', clean_text)
-    clean_text = re.sub(r'\s+', ' ', clean_text)
-    return clean_text
+# formerly Text subgroup
+# raw words aka not-PTB-tokens
+SINGLE_RAW_WORD = [
+    ('word_first', Substance.DISCRETE),
+    ('word_last', Substance.DISCRETE),
+    ('bigram_first', Substance.DISCRETE),
+    ('bigram_last', Substance.DISCRETE),
+    ('num_tokens', Substance.CONTINUOUS)
+]
 
 
-def clean_corpus_word(word):
-    """
-    Given a word from the corpus, return a slightly normalised
-    version of that word
-    """
-    return word.lower()
-
-
-def tokens_feature(wrapped):
-    """
-    Lift a function from `tokens -> feature` to
-    `single_function_input -> feature`
-    """
-    @edu_feature
-    @wraps(wrapped)
-    def inner(edu):
-        "(edu -> f) -> ((context, edu) -> f)"
-        tokens = [tune_for_csv(clean_corpus_word(x))
-                  for x in clean_edu_text(edu.text()).split()]
-        return wrapped(tokens)
-    return inner
-
-
-def ptb_tokens_feature(wrapped):
-    """
-    Lift a function from `[ptb_token] -> feature`
-    to `single_function_input -> feature`
-    """
-    @wraps(wrapped)
-    def inner(context, edu):
-        "([ptb_token] -> f) -> ((context, edu) -> f)"
-        tokens = context.ptb_tokens[edu]
-        return wrapped(tokens) if tokens is not None else None
-    return inner
-
-
-# ---------------------------------------------------------------------
-# single EDU features
-# ---------------------------------------------------------------------
-
-# not-PTB-tokens
-
-@tokens_feature
-@on_first_unigram
-def word_first(token):
-    "first word in the EDU (normalised)"
-    return token
-
-
-@tokens_feature
-@on_last_unigram
-def word_last(token):
-    "last word in the EDU (normalised)"
-    return token
-
-
-@tokens_feature
-@on_first_bigram
-def bigram_first(token):
-    "first two words in the EDU (normalised)"
-    return token
-
-
-@tokens_feature
-@on_last_bigram
-def bigram_last(token):
-    "first two words in the EDU (normalised)"
-    return token
-
-
-@tokens_feature
-def num_tokens(tokens):
-    "number of distinct tokens in EDU text"
-    return len(tokens)
+def extract_single_raw_word(edu_info):
+    """raw word features for the EDU"""
+    raw_words = edu_info['raw_words']
+    if raw_words:
+        yield ('word_first', raw_words[0])
+        yield ('word_last', raw_words[-1])
+    if len(raw_words) > 1:
+        yield ('bigram_first', (raw_words[0], raw_words[1]))
+        yield ('bigram_last', (raw_words[-2], raw_words[-1]))
+    yield ('num_tokens', len(raw_words))
 
 
 # PTB tokens
+# note: PTB tokens may not necessarily correspond to words
 
-@ptb_tokens_feature
-@on_first_unigram
-def ptb_pos_tag_first(token):
-    "POS tag for first PTB token in the EDU"
-    # note: PTB tokens may not necessarily correspond to words
-    return token.tag
-
-
-@ptb_tokens_feature
-@on_last_unigram
-def ptb_pos_tag_last(token):
-    "POS tag for last PTB token in the EDU"
-    # note: PTB tokens may not necessarily correspond to words
-    return token.tag
+SINGLE_PTB_TOKEN_WORD = [
+    ('ptb_word_first', Substance.DISCRETE),
+    ('ptb_word_last', Substance.DISCRETE),
+    ('ptb_word_first2', Substance.DISCRETE),
+    ('ptb_word_last2', Substance.DISCRETE)
+]
 
 
-@ptb_tokens_feature
-@on_first_unigram
-def ptb_word_first(token):
-    "first PTB word in the EDU"
-    return token.word
+def extract_single_ptb_token_word(edu_info):
+    """word features on PTB tokens for the EDU"""
+    try:
+        words = edu_info['words']
+    except KeyError:
+        return
+
+    if words:
+        yield ('ptb_word_first', words[0])
+        yield ('ptb_word_last', words[-1])
+
+    if len(words) > 1:
+        yield ('ptb_word_first2', (words[0], words[1]))
+        yield ('ptb_word_last2', (words[-2], words[-1]))
 
 
-@ptb_tokens_feature
-@on_last_unigram
-def ptb_word_last(token):
-    "last PTB word in the EDU"
-    return token.word
+SINGLE_PTB_TOKEN_POS = [
+    ('ptb_pos_tag_first', Substance.DISCRETE),
+    ('ptb_pos_tag_last', Substance.DISCRETE),
+    ('ptb_pos_tag_first2', Substance.DISCRETE),
+    ('ptb_pos_tag_last2', Substance.DISCRETE),
+]
 
 
-@ptb_tokens_feature
-@on_first_bigram
-def ptb_pos_tag_first2(token):
-    "POS tag for first two PTB tokens in the EDU"
-    # note: PTB tokens may not necessarily correspond to words
-    return token.tag
+def extract_single_ptb_token_pos(edu_info):
+    """POS features on PTB tokens for the EDU"""
+    try:
+        tags = edu_info['tags']
+    except KeyError:
+        return
+
+    if tags:
+        yield ('ptb_pos_tag_first', tags[0])
+        yield ('ptb_pos_tag_last', tags[-1])
+
+    if len(tags) > 1:
+        yield ('ptb_pos_tag_first2', (tags[0], tags[1]))
+        yield ('ptb_pos_tag_last2', (tags[-2], tags[-1]))
 
 
-@ptb_tokens_feature
-@on_last_bigram
-def ptb_pos_tag_last2(token):
-    "POS tag for last two PTB tokens in the EDU"
-    # note: PTB tokens may not necessarily correspond to words
-    return token.tag
+def build_edu_feature_extractor():
+    """Build the feature extractor for single EDUs"""
+    feats = []
+    funcs = []
 
+    # raw word
+    feats.extend(SINGLE_RAW_WORD)
+    funcs.append(extract_single_raw_word)
+    # PTB word
+    feats.extend(SINGLE_PTB_TOKEN_WORD)
+    funcs.append(extract_single_ptb_token_word)
+    # PTB pos
+    feats.extend(SINGLE_PTB_TOKEN_POS)
+    funcs.append(extract_single_ptb_token_pos)
 
-@ptb_tokens_feature
-@on_first_bigram
-def ptb_word_first2(token):
-    "first two PTB words in the EDU"
-    return token.word
+    def _extract_all(edu_info):
+        """inner helper because I am lost at sea here"""
+        # TODO do this in a cleaner manner
+        for fct in funcs:
+            for feat in fct(edu_info):
+                yield feat
 
-
-@ptb_tokens_feature
-@on_last_bigram
-def ptb_word_last2(token):
-    "last PTB words in the EDU"
-    return token.word
+    # header
+    header = feats
+    # extractor
+    feat_extractor = _extract_all
+    # return header and extractor
+    return header, feat_extractor
 
 
 # ---------------------------------------------------------------------
 # pair EDU features
 # ---------------------------------------------------------------------
 
-@edu_pair_feature
-def num_edus_between(edu1, edu2):
-    "number of EDUs between the two EDUs"
-    return abs(edu2.num - edu1.num) - 1
+PAIR_GAP = [
+    ('num_edus_between', Substance.CONTINUOUS),
+    ('same_paragraph', Substance.DISCRETE),
+    ('same_bad_sentence', Substance.DISCRETE),
+    ('same_ptb_sentence', Substance.DISCRETE)
+]
 
 
-def same_paragraph(current, edu1, edu2):
-    "if in the same paragraph"
-    para1 = get_paragraph(current, edu1)
-    para2 = get_paragraph(current, edu2)
-    return para1 is not None and para2 is not None and\
-        para1 == para2
+def extract_pair_gap(edu_info1, edu_info2):
+    """Document tuple features"""
+    edu_num1 = edu_info1['edu'].num
+    edu_num2 = edu_info2['edu'].num
+
+    edu_num_diff = abs(edu_num2 - edu_num1) - 1
+    yield ('num_edus_between', edu_num_diff)
+
+    try:
+        para_id1 = edu_info1['para_idx']
+        para_id2 = edu_info2['para_idx']
+    except KeyError:
+        pass
+    else:
+        same_para = (para_id1 is not None and
+                     para_id2 is not None and
+                     para_id1 == para_id2)
+        yield ('same_paragraph', same_para)
+
+    # same sentence, raw segmentation
+    raw_sent_id1 = edu_info1['raw_sent_idx']
+    raw_sent_id2 = edu_info2['raw_sent_idx']
+    same_bad_sent = (raw_sent_id1 is not None and
+                     raw_sent_id2 is not None and
+                     raw_sent_id1 == raw_sent_id2)
+    yield ('same_bad_sentence', same_bad_sent)
+
+    # same sentence, ptb segmentation
+    # FIXME fix behaviour for sentences with no gold segmentation,
+    # as then edu2sent = edu2raw_sent
+    sent_id1 = edu_info1['sent_idx']
+    sent_id2 = edu_info2['sent_idx']
+    same_ptb_sent = (sent_id1 is not None and
+                     sent_id2 is not None and
+                     sent_id1 == sent_id2)
+    yield ('same_ptb_sentence', same_ptb_sent)
 
 
-def same_bad_sentence(current, edu1, edu2):
-    "if in the same sentence (bad segmentation)"
-    sent1 = get_sentence(current, edu1)
-    sent2 = get_sentence(current, edu2)
-    return sent1 is not None and sent2 is not None and\
-        sent1 == sent2
+PAIR_RAW_WORD = [
+    ('word_first_pairs', Substance.DISCRETE),
+    ('word_last_pairs', Substance.DISCRETE),
+    ('bigram_first_pairs', Substance.DISCRETE),
+    ('bigram_last_pairs', Substance.DISCRETE),
+]
 
 
-def same_ptb_sentence(current, edu1, edu2):
-    "if in the same sentence (ptb segmentation)"
-    sents1 = current.ptb_trees[edu1]
-    sents2 = current.ptb_trees[edu2]
-    if sents1 is None or sents2 is None:
-        return False
-    has_overlap = bool([s for s in sents1 if s in sents2])
-    return has_overlap
+def extract_pair_raw_word(edu_info1, edu_info2):
+    """raw word features on EDU pairs"""
+    raw_words1 = edu_info1['raw_words']
+    raw_words2 = edu_info2['raw_words']
+
+    if raw_words1 and raw_words2:
+        yield ('word_first_pairs', (raw_words1[0], raw_words2[0]))
+        yield ('word_last_pairs', (raw_words1[-1], raw_words2[0]))
+
+    if len(raw_words1) > 1 and len(raw_words2) > 1:
+        yield ('bigram_first_pairs', ((raw_words1[0], raw_words1[1]),
+                                      (raw_words2[0], raw_words2[1])))
+        yield ('bigram_last_pairs', ((raw_words1[-2], raw_words1[-1]),
+                                     (raw_words2[-2], raw_words2[-1])))
 
 
-@tuple_feature(underscore)
-def word_first_pairs(_, cache, edu):
-    "pair of the first words in the two EDUs"
-    return cache[edu]["word_first"]
+PAIR_POS_TAGS = [
+    ('ptb_pos_tag_first_pairs', Substance.DISCRETE)
+]
 
 
-@tuple_feature(underscore)
-def word_last_pairs(_, cache, edu):
-    "pair of the last words in the two EDUs"
-    return cache[edu]["word_last"]
+def extract_pair_pos_tags(edu_info1, edu_info2):
+    """POS tag features on EDU pairs"""
+    try:
+        tags1 = edu_info1['tags']
+        tags2 = edu_info2['tags']
+    except KeyError:
+        return
+
+    if tags1 and tags2:
+        yield ('ptb_pos_tag_first_pairs', (tags1[0], tags2[0]))
 
 
-@tuple_feature(underscore)
-def bigram_first_pairs(_, cache, edu):
-    "pair of the first bigrams in the two EDUs"
-    return cache[edu]["bigram_first"]
+def build_pair_feature_extractor():
+    """Build the feature extractor for pairs of EDUs
 
-
-@tuple_feature(underscore)
-def bigram_last_pairs(_, cache, edu):
-    "pair of the last bigrams in the two EDUs"
-    return cache[edu]["bigram_last"]
-
-
-@tuple_feature(underscore)
-def ptb_pos_tag_first_pairs(_, cache, edu):
-    "pair of the first POS in the two EDUs"
-    return cache[edu]["ptb_pos_tag_first"]
-
-
-def ptb_pos_tags_in_first(current, edu1, _):
-    "demonstrator for use of basket features"
-    tokens = current.ptb_tokens[edu1]
-    return Counter(t.tag for t in tokens) if tokens is not None else None
-
-
-# ---------------------------------------------------------------------
-# single EDU key groups
-# ---------------------------------------------------------------------
-
-class SingleEduSubgroup_Meta(SingleEduSubgroup):
+    TODO: properly emit features on single EDUs ;
+    they are already stored in sf_cache, but under (slightly) different
+    names
     """
-    Basic EDU-identification features
-    """
+    feats = []
+    funcs = []
 
-    _features =\
-        [MagicKey.meta_fn(feat_id),
-         MagicKey.meta_fn(feat_start),
-         MagicKey.meta_fn(feat_end)]
+    feats.extend(PAIR_GAP)
+    funcs.append(extract_pair_gap)
 
-    def __init__(self):
-        desc = self.__doc__.strip()
-        super(SingleEduSubgroup_Meta, self).__init__(desc, self._features)
+    feats.extend(PAIR_RAW_WORD)
+    funcs.append(extract_pair_raw_word)
 
+    feats.extend(PAIR_POS_TAGS)
+    funcs.append(extract_pair_pos_tags)
 
-class SingleEduSubgroup_Text(SingleEduSubgroup):
-    """
-    Properties of the EDU text itself
-    """
-    _features =\
-        [MagicKey.discrete_fn(word_first),
-         MagicKey.discrete_fn(word_last),
-         MagicKey.discrete_fn(bigram_first),
-         MagicKey.discrete_fn(bigram_last),
-         MagicKey.continuous_fn(num_tokens)]
+    def _extract_all(edu_info1, edu_info2):
+        """inner helper because I am lost at sea here, again"""
+        # TODO do this in a cleaner manner
+        for fct in funcs:
+            for feat in fct(edu_info1, edu_info2):
+                yield feat
 
-    def __init__(self):
-        desc = self.__doc__.strip()
-        super(SingleEduSubgroup_Text, self).__init__(desc, self._features)
-
-
-class SingleEduSubgroup_Ptb(SingleEduSubgroup):
-    """
-    Penn Treebank properties for the EDU
-    """
-    _features =\
-        [MagicKey.discrete_fn(ptb_word_first),
-         MagicKey.discrete_fn(ptb_word_last),
-         MagicKey.discrete_fn(ptb_pos_tag_first),
-         MagicKey.discrete_fn(ptb_pos_tag_last),
-         MagicKey.discrete_fn(ptb_word_first2),
-         MagicKey.discrete_fn(ptb_word_last2),
-         MagicKey.discrete_fn(ptb_pos_tag_first2),
-         MagicKey.discrete_fn(ptb_pos_tag_last2)]
-
-    def __init__(self):
-        desc = self.__doc__.strip()
-        super(SingleEduSubgroup_Ptb, self).__init__(desc, self._features)
-
-
-# ---------------------------------------------------------------------
-# EDU pairs
-# ---------------------------------------------------------------------
-
-class PairSubGroup_Core(PairSubgroup):
-    """core features"""
-
-    def __init__(self):
-        desc = self.__doc__.strip()
-        keys =\
-            [MagicKey.meta_fn(feat_grouping)]
-        super(PairSubGroup_Core, self).__init__(desc, keys)
-
-
-class PairSubgroup_Gap(PairSubgroup):
-    """
-    Features related to the combined surrounding context of the
-    two EDUs
-    """
-
-    def __init__(self):
-        desc = "the gap between EDUs"
-        keys =\
-            [MagicKey.continuous_fn(num_edus_between),
-             MagicKey.discrete_fn(same_paragraph),
-             MagicKey.discrete_fn(same_bad_sentence),
-             MagicKey.discrete_fn(same_ptb_sentence)]
-        super(PairSubgroup_Gap, self).__init__(desc, keys)
-
-
-# largely c/c'ed from educe.stac.learning.features
-class PairSubgroup_Tuple(PairSubgroup):
-    "artificial tuple features"
-
-    def __init__(self, sf_cache):
-        self.sf_cache = sf_cache
-        desc = self.__doc__.strip()
-        keys =\
-            [MagicKey.discrete_fn(word_first_pairs),
-             MagicKey.discrete_fn(word_last_pairs),
-             MagicKey.discrete_fn(bigram_first_pairs),
-             MagicKey.discrete_fn(bigram_last_pairs),
-             MagicKey.discrete_fn(ptb_pos_tag_first_pairs)]
-        super(PairSubgroup_Tuple, self).__init__(desc, keys)
-
-    def fill(self, current, edu1, edu2, target=None):
-        vec = self if target is None else target
-        for key in self.keys:
-            vec[key.name] = key.function(current, self.sf_cache, edu1, edu2)
-
-
-class PairSubgroup_Basket(PairSubgroup):
-    """
-    Sparse features
-    """
-    _features =\
-        [MagicKey.basket_fn(ptb_pos_tags_in_first)]
-
-    def __init__(self):
-        desc = self.__doc__.strip()
-        super(PairSubgroup_Basket, self).__init__(desc, self._features)
-
-
-# export groups
-class SingleEduKeys(BaseSingleEduKeys):
-    """Single EDU features"""
-
-    def __init__(self):
-        groups = [
-            SingleEduSubgroup_Meta(),
-            SingleEduSubgroup_Text(),
-            SingleEduSubgroup_Ptb()
-        ]
-        super(SingleEduKeys, self).__init__(groups)
-
-
-class PairKeys(BasePairKeys):
-    """Features on a pair of EDUs"""
-
-    def __init__(self, sf_cache=None):
-        groups = [
-            PairSubGroup_Core(),
-            PairSubgroup_Gap(),
-            PairSubgroup_Tuple(sf_cache),
-            PairSubgroup_Basket()
-        ]
-        super(PairKeys, self).__init__(groups, sf_cache)
-
-    def init_single_features(self):
-        """Init features defined on single EDUs"""
-        return SingleEduKeys()
+    # header
+    header = feats
+    # extractor
+    feat_extractor = _extract_all
+    # return header and extractor
+    return header, feat_extractor

--- a/educe/rst_dt/learning/tests.py
+++ b/educe/rst_dt/learning/tests.py
@@ -1,0 +1,23 @@
+from educe.rst_dt.learning.base import relative_indices
+
+
+def test_relative_indices():
+    """Test for relative_indices"""
+    # first example: common case
+    example1 = [0, 1, 1, 1, 2, 3, 3]
+
+    rel_exa1 = [0, 0, 1, 2, 0, 0, 1]
+    assert relative_indices(example1) == rel_exa1
+
+    inv_exa1 = [0, 2, 1, 0, 0, 1, 0]
+    assert relative_indices(example1, reverse=True) == inv_exa1
+
+    # second example: case with None
+    # each None is considered to be a distinct subgroup
+    example2 = [None, 0, 1, 1, None, None]
+    
+    rel_exa2 = [0, 0, 0, 1, 0, 0]
+    assert relative_indices(example2) == rel_exa2
+
+    inv_exa2 = [0, 0, 1, 0, 0, 0]
+    assert relative_indices(example2, reverse=True) == inv_exa2

--- a/educe/rst_dt/parse.py
+++ b/educe/rst_dt/parse.py
@@ -23,7 +23,7 @@ from .annotation import\
     RSTTreeException,\
     EDU, Node,\
     RSTContext, RSTTree, SimpleRSTTree
-from .text import parse_text
+from .rst_wsj_corpus import load_rst_wsj_corpus_text_file
 from ..external.postag import generic_token_spans
 from ..internalutil import treenode
 
@@ -218,12 +218,15 @@ def read_annotation_file(anno_filename, text_filename):
     Read a single RST tree
     """
     tree = None
-    with codecs.open(text_filename, 'r', 'utf-8') as stream:
-        text = stream.read()
-        text_annos = parse_text(text)
-        context = RSTContext(text, text_annos)
+
+    # read text file
+    text, text_annos = load_rst_wsj_corpus_text_file(text_filename)
+    # use it as context for the RST tree
+    context = RSTContext(text, text_annos)
+    # read RST tree
     with codecs.open(anno_filename, 'r', 'utf-8') as stream:
         tree = parse_rst_dt_tree(stream.read(), context)
+
     return tree
 
 

--- a/educe/rst_dt/ptb.py
+++ b/educe/rst_dt/ptb.py
@@ -140,13 +140,14 @@ class PtbParser(object):
 
         Return a tokenized document.
         """
-        # get doc text
-        # here we cheat and get it from the RST-DT tree
-        rst_text = doc.orig_rsttree.text()
         # get tokens from PTB
         ptb_name = _guess_ptb_name(doc.key)
         if ptb_name is None:
             return doc
+
+        # get doc text
+        # here we cheat and get it from the RST-DT tree
+        rst_text = doc.orig_rsttree.text()
         tagged_tokens = self.reader.tagged_words(ptb_name)
         # tweak tokens THEN filter empty nodes
         tweaked1, tweaked2 =\
@@ -156,8 +157,10 @@ class PtbParser(object):
         spans = generic_token_spans(rst_text, tweaked1,
                                     txtfn=lambda x: x.tweaked_word)
         result = [_mk_token(t, s) for t, s in izip(tweaked2, spans)]
+
         # store in doc
-        doc.tkd_tokens = result
+        doc.tkd_tokens.extend(result)
+
         return doc
 
     def parse(self, doc):
@@ -171,12 +174,14 @@ class PtbParser(object):
 
         Note: does nothing if there is no associated PTB corpus entry.
         """
-        # get tokens from tokenized document
-        tokens_iter = iter(doc.tkd_tokens)
         # get PTB trees
         ptb_name = _guess_ptb_name(doc.key)
         if ptb_name is None:
             return doc
+
+        # get tokens from tokenized document
+        tokens_iter = iter(doc.tkd_tokens)
+
         results = []
         for tree in self.reader.parsed_sents(ptb_name):
             # apply standard cleaning to tree

--- a/educe/rst_dt/rst_wsj_corpus.py
+++ b/educe/rst_dt/rst_wsj_corpus.py
@@ -1,3 +1,8 @@
+"""This module provides loaders for file formats found in the RST-WSJ-corpus.
+"""
+
+from __future__ import print_function
+
 import codecs
 import os
 
@@ -43,10 +48,9 @@ def load_rst_wsj_corpus_edus_file(f):
 FIL_SEP_PARA = '\n\n'  # probably useless
 FIL_SEP_SENT = '\n  '
 
-# TODO move to more relevant place (?)
-# TODO use this info :-)
-file_to_ptb = {'file1': 'wsj_0764',
-}
+
+# TODO complete, move to more relevant place (?) and use this info
+FILE_TO_PTB = {'file1': 'wsj_0764'}
 
 
 def _load_rst_wsj_corpus_text_file_file(f):
@@ -74,7 +78,7 @@ def _load_rst_wsj_corpus_text_file_file(f):
     # TODO remove trailing '\n' of last sentence
 
     return text, output_paras
-    
+
 
 def load_rst_wsj_corpus_text_file_file(f):
     """Load a text file whose name is of the form `file##`
@@ -154,5 +158,7 @@ def load_rst_wsj_corpus_text_file(f):
     elif bn_prefix == 'wsj_':
         return load_rst_wsj_corpus_text_file_wsj(f)
     else:
-        raise ValueError('Unsupported file: {}'.format(f))
-
+        # raise ValueError(err_msg.format(f))
+        err_msg = 'W: using wsj_ loader for file of unknown type: {}'
+        print(err_msg.format(f))
+        return load_rst_wsj_corpus_text_file_wsj(f)

--- a/educe/rst_dt/rst_wsj_corpus.py
+++ b/educe/rst_dt/rst_wsj_corpus.py
@@ -1,0 +1,158 @@
+import codecs
+import os
+
+from educe.annotation import Span
+from educe.rst_dt.text import Paragraph, Sentence
+
+
+def _load_rst_wsj_corpus_edus_file(f):
+    """Actually do load"""
+    txt = []
+    offset = []
+    for line in f:
+        # line pattern: '    <EDU>\n' (4 spaces, EDU text, newline)
+        edu_txt = line.strip()
+        txt.append(edu_txt)
+        offset.append(len(edu_txt))
+    # FIXME ' '.join() can introduce whitespaces not in the original text
+    # at least partly due to bad EDU segmentation
+    clean_txt = ' '.join(txt)
+    return clean_txt, offset
+
+
+def load_rst_wsj_corpus_edus_file(f):
+    """Load a file that contains the EDUs of a document.
+
+    Return clean text and the list of EDU offsets on the clean text.
+    """
+    with codecs.open(f, 'r', 'utf-8') as f:
+        clean_txt, offset = _load_rst_wsj_corpus_edus_file(f)
+    return (clean_txt, offset)
+
+
+# TODO what the _text_ functions in this module should return is
+# clean text plus the extractible annotation,
+# i.e. paragraph spans (if any) and sentence spans,
+# *on the clean text*
+
+##############
+# file## files
+##############
+
+# TODO: maybe don't generate Paragraph, as there is no paragraph marking
+FIL_SEP_PARA = '\n\n'  # probably useless
+FIL_SEP_SENT = '\n  '
+
+# TODO move to more relevant place (?)
+# TODO use this info :-)
+file_to_ptb = {'file1': 'wsj_0764',
+}
+
+
+def _load_rst_wsj_corpus_text_file_file(f):
+    """Actually do load"""
+    text = f.read()
+
+    start = 0
+    sent_id = 0
+    output_paras = []
+    for para_id, paragraph in enumerate(text.split(FIL_SEP_PARA)):
+        output_sentences = []
+        for sentence in paragraph.split(FIL_SEP_SENT):
+            end = start + len(sentence)
+            # NEW: remove leading white spaces
+            lws = len(sentence) - len(sentence.lstrip())
+            if lws:
+                start += lws
+            # end NEW
+            if end > start:
+                output_sentences.append(Sentence(sent_id, Span(start, end)))
+                sent_id += 1
+            start = end + 3  # + 3 for + len(FIL_SEP_SENT)
+        output_paras.append(Paragraph(para_id, output_sentences))
+        start -= 1  # start += len(FIL_SEP_PARA) - len(FIL_SEP_SENT)
+    # TODO remove trailing '\n' of last sentence
+
+    return text, output_paras
+    
+
+def load_rst_wsj_corpus_text_file_file(f):
+    """Load a text file whose name is of the form `file##`
+
+    These files do not mark paragraphs.
+    Each line contains a sentence preceded by two or three leading spaces.
+    """
+    with codecs.open(f, 'r', 'utf-8') as f:
+        text, paragraphs = _load_rst_wsj_corpus_text_file_file(f)
+    return (text, paragraphs)
+
+
+##################
+# wsj_## files
+##################
+WSJ_SEP_PARA = ' \n\n'  # was: '\n\n'
+WSJ_SEP_SENT = '\n'
+
+
+def _load_rst_wsj_corpus_text_file_wsj(f):
+    """Actually do load"""
+    text = f.read()
+
+    start = 0
+    sent_id = 0
+    output_paras = []
+    for para_id, paragraph in enumerate(text.split(WSJ_SEP_PARA)):
+        output_sentences = []
+        for sentence in paragraph.split(WSJ_SEP_SENT):
+            end = start + len(sentence)
+            # NEW: remove trailing white space
+            rws = len(sentence) - len(sentence.rstrip())
+            if rws:
+                end -= rws
+            # end NEW
+            if end > start:
+                output_sentences.append(Sentence(sent_id, Span(start, end)))
+                sent_id += 1
+            start = end + rws + 1  # + 1 for + len(WSJ_SEP_SENT)
+        output_paras.append(Paragraph(para_id, output_sentences))
+        start += 2  # whitespace and second newline
+
+    return text, output_paras
+
+
+def load_rst_wsj_corpus_text_file_wsj(f):
+    """Load a text file whose name is of the form `wsj_##`
+
+    By convention:
+
+    * paragraphs are separated by double newlines
+    * sentences by single newlines
+
+    Note that this segmentation isn't particularly reliable, and
+    seems to both over- (e.g. cut at some abbreviations, like "Prof.")
+    and under-segment (e.g. not separate contiguous sentences).
+    It shouldn't be taken too seriously, but if you need some sort of
+    rough approximation, it may be helpful.
+    """
+    with codecs.open(f, 'r', 'utf-8') as f:
+        text, paragraphs = _load_rst_wsj_corpus_text_file_wsj(f)
+    return (text, paragraphs)
+
+
+def load_rst_wsj_corpus_text_file(f):
+    """Load a text file from the RST-WSJ-CORPUS.
+
+    Return a sequence of Paragraph annotations from an RST text.
+
+    The corpus contains two types of text files, so this function is
+    mainly an entry point that delegates to the appropriate function.
+    """
+    bn = os.path.basename(f)
+    bn_prefix = bn[:4]
+    if bn_prefix == 'file':
+        return load_rst_wsj_corpus_text_file_file(f)
+    elif bn_prefix == 'wsj_':
+        return load_rst_wsj_corpus_text_file_wsj(f)
+    else:
+        raise ValueError('Unsupported file: {}'.format(f))
+

--- a/educe/rst_dt/text.py
+++ b/educe/rst_dt/text.py
@@ -15,6 +15,8 @@ Educe-style annotations for RST discourse treebank text
 objects (paragraphs and sentences)
 """
 
+import re
+
 from educe.annotation import Standoff, Span
 
 
@@ -68,30 +70,13 @@ class Sentence(Standoff):
         return cls(cls._lpad_num, cls._lpad_span)
 
 
-def parse_text(text):
+# helper function, formerly in learning.features
+def clean_edu_text(text):
     """
-    Return a sequence of Paragraph annotations from an RST text.
-    By convention:
-
-    * paragraphs are separated by double newlines
-    * sentences by single newlines
-
-    Note that this segmentation isn't particularly reliable, and
-    seems to cut at some abbreviations, like "Prof.". It shouldn't
-    be taken too seriously, but if you need some sort of rough
-    approximation, it may be helpful.
+    Strip metadata from EDU text and compress extraneous whitespace
     """
-    start = 0
-    sent_id = 0
-    output_paras = []
-    for para_id, paragraph in enumerate(text.split("\n\n")):
-        output_sentences = []
-        for sentence in paragraph.split("\n"):
-            end = start + len(sentence)
-            if end > start:
-                output_sentences.append(Sentence(sent_id, Span(start, end)))
-                sent_id += 1
-            start = end + 1  # newline
-        output_paras.append(Paragraph(para_id, output_sentences))
-        start += 1  # second newline
-    return output_paras
+    clean_text = text
+    clean_text = re.sub(r'(\.|,)*$', r'', clean_text)
+    clean_text = re.sub(r'^"', r'', clean_text)
+    clean_text = re.sub(r'\s+', ' ', clean_text)
+    return clean_text

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ REQS = \
      'python-graph-dot',
      'frozendict',
      'sh',
-     'nltk == 3.0.0',
+     'nltk >= 3.0.0',
      'soundex']
 
 


### PR DESCRIPTION
This PR introduces a new way to extract features on documents from the RST-WSJ-corpus, plus some refactoring that happened along the way.
The output is designed to meet the needs of the scikit branches of attelo and irit-rst-dt ; it consists of files listing the EDUs, EDU pairings, sparse features in the svmlight format and feature vocabulary.
The feature extraction process is controlled by a DocumentVectorizer, which enables the filtering of features that are too rare or too common among documents.