### PR TITLE
Improvements to the alignment of RST-WSJ with PTB

### DIFF
--- a/educe/rst_dt/document_plus.py
+++ b/educe/rst_dt/document_plus.py
@@ -223,6 +223,7 @@ class DocumentPlus(object):
 
         return self
 
+    # START HERE: move functionality to ptb.py
     def align_with_tokens(self):
         """Compute for each EDU the overlapping tokens"""
         tokens = self.tkd_tokens
@@ -326,6 +327,8 @@ class DocumentPlus(object):
         self.ptb_trees = ptb_trees  # mark for deprecation
 
         return self
+    # END HERE: move to ptb.py
+
 
     def all_edu_pairs(self):
         """Generate all EDU pairs of a document"""

--- a/educe/rst_dt/document_plus.py
+++ b/educe/rst_dt/document_plus.py
@@ -223,7 +223,7 @@ class DocumentPlus(object):
 
         return self
 
-    # START HERE: move functionality to ptb.py
+    # TODO move functionality to ptb.py
     def align_with_tokens(self):
         """Compute for each EDU the overlapping tokens"""
         tokens = self.tkd_tokens
@@ -262,6 +262,7 @@ class DocumentPlus(object):
 
         return self
 
+    # TODO move functionality to ptb.py
     def align_with_trees(self):
         """Compute for each EDU the overlapping trees"""
         syn_trees = self.tkd_trees
@@ -327,8 +328,6 @@ class DocumentPlus(object):
         self.ptb_trees = ptb_trees  # mark for deprecation
 
         return self
-    # END HERE: move to ptb.py
-
 
     def all_edu_pairs(self):
         """Generate all EDU pairs of a document"""

--- a/educe/rst_dt/learning/features_li2014.py
+++ b/educe/rst_dt/learning/features_li2014.py
@@ -201,7 +201,8 @@ def extract_single_syntax(edu_info):
     """syntactic features for the EDU"""
     syn_labels = get_syntactic_labels(edu_info)
     if syn_labels is not None:
-        yield ('SYN', syn_labels)
+        for syn_label in syn_labels:
+            yield ('SYN', syn_label)
 
 
 # TODO: features on semantic similarity
@@ -227,7 +228,7 @@ def build_edu_feature_extractor():
     feats.extend(SINGLE_SENTENCE)
     funcs.append(extract_single_sentence)
     # syntax (disabled)
-    # feats.extend(_single_syntax)
+    # feats.extend(SINGLE_SYNTAX)
     # funcs.append(extract_single_syntax)
 
     def _extract_all(edu_info):

--- a/educe/rst_dt/ptb.py
+++ b/educe/rst_dt/ptb.py
@@ -22,7 +22,7 @@ from educe.annotation import Span
 from educe.external.parser import\
     ConstituencyTree
 from educe.external.postag import\
-    generic_token_spans, Token, EducePosTagException
+    generic_token_spans, Token
 from educe.internalutil import izip
 from educe.ptb.annotation import\
     PTB_TO_TEXT, is_nonword_token, TweakedToken,\
@@ -91,7 +91,7 @@ PTB_MISSING_TEXT = [
 
 # docs for which the RST-WSJ-corpus file misses text at the end of the doc
 RST_MISSING_TEXT = [
-#    'file1',  # handled in _PTB_SUBSTS_OTHER under wsj_0764
+    # 'file1',  # handled in _PTB_SUBSTS_OTHER under wsj_0764
 ]
 
 

--- a/educe/rst_dt/ptb.py
+++ b/educe/rst_dt/ptb.py
@@ -2,7 +2,7 @@
 # License: CeCILL-B (French BSD3-like)
 
 """
-Alignment between the RST-WSJ-corpus and the Penn Treebank
+Alignment the RST-WSJ-corpus with the Penn Treebank
 """
 
 from __future__ import print_function

--- a/educe/rst_dt/ptb.py
+++ b/educe/rst_dt/ptb.py
@@ -121,7 +121,7 @@ RST_WRONG_EDU_SEG = [
 _PTB_EXTRA_FULLSTOPS =\
     [('06/wsj_0617.mrg', 966),
      ('06/wsj_0695.mrg', 64),
-     ('07/wsj_0764.mrg', 882),
+     ('07/wsj_0764.mrg', 882),  # aka file1
      ('11/wsj_1101.mrg', 736),
      ('11/wsj_1125.mrg', 222),
      ('13/wsj_1318.mrg', 212),
@@ -246,7 +246,6 @@ class PtbParser(object):
         rst_text = doc.orig_rsttree.text()
         tagged_tokens = self.reader.tagged_words(ptb_name)
         # tweak tokens THEN filter empty nodes
-
         tweaked1, tweaked2 =\
             itertools.tee(_tweak_token(ptb_name)(i, tok) for i, tok in
                           enumerate(tagged_tokens)

--- a/educe/rst_dt/rst_wsj_corpus.py
+++ b/educe/rst_dt/rst_wsj_corpus.py
@@ -49,10 +49,6 @@ FIL_SEP_PARA = '\n\n'  # probably useless
 FIL_SEP_SENT = '\n  '
 
 
-# TODO complete, move to more relevant place (?) and use this info
-FILE_TO_PTB = {'file1': 'wsj_0764'}
-
-
 def _load_rst_wsj_corpus_text_file_file(f):
     """Actually do load"""
     text = f.read()


### PR DESCRIPTION
This PR fixes a bug affecting the RST-WSJ to PTB alignment (my mistake, about the fake token) that should affect syntactic features.
It also fixes the feature extraction for syntactic features in the `li2014` set.
Last, it completes the alignment from RST-WSJ to PTB by adding substitutions for the `fileN` files from RST-WSJ.
We might now be able to include all documents from RST-WSJ in our experiments.
The mapping is so labor-intensive that I am unsure other groups have gone into such trouble for a handful of documents.